### PR TITLE
Process head commit instead of all commits of the PR

### DIFF
--- a/src/main/kotlin/com/ippontech/blog/import/GithubEvent.kt
+++ b/src/main/kotlin/com/ippontech/blog/import/GithubEvent.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class GithubEvent(
         val ref: String,
-        val commits: Array<Commit>
+        val head_commit: Commit
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/com/ippontech/blog/import/GithubWebhook.kt
+++ b/src/main/kotlin/com/ippontech/blog/import/GithubWebhook.kt
@@ -34,7 +34,7 @@ class LambdaHandler : RequestHandler<Map<String, Any>, WebhookResult> {
             }
 
             val pushEventHandler = PushEventHandler()
-            event.commits.map { pushEventHandler.processCommit(it) }
+            pushEventHandler.processCommit(event.head_commit)
 
             logger.info("Done")
             return WebhookResult(200, "Success")


### PR DESCRIPTION
The lambda will now only process the **head_commit** to avoid processing all the commits of the PR which was causing issues when a post was renamed for example.